### PR TITLE
Define setting

### DIFF
--- a/settings/Osdi.setting.php
+++ b/settings/Osdi.setting.php
@@ -1,0 +1,15 @@
+<?php
+return array(
+  'multisite_acl_enabled' => array(
+    'group_name' => 'OSDI',
+    'group' => 'osdi',
+    'name' => 'server_time_zone',
+    'type' => 'String', //Wish there was something to capture non-integer numbers
+    'default' => 0,
+    'add' => '5.4',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Time zone offset for OSDI interactions',
+    'help_text' => 'Time zone offset of local server',
+  ),
+);

--- a/settings/Osdi.setting.php
+++ b/settings/Osdi.setting.php
@@ -4,6 +4,7 @@ return array(
     'group_name' => 'OSDI',
     'group' => 'osdi',
     'name' => 'server_time_zone',
+    'title' => 'OSDI Server Time Zone',
     'type' => 'String', //Wish there was something to capture non-integer numbers
     'default' => 0,
     'add' => '5.4',


### PR DESCRIPTION
Settings in extensions must be [defined with metadata](https://docs.civicrm.org/dev/en/latest/framework/setting/#creating-a-new-setting-in-an-extension), so that various functions can incorporate it seamlessly.  This PR defines the local time zone in settings metadata; I know there are more settings, but this is a start.

As a sidebar, I'm not sure this particular setting is necessary.  I think you can accomplish the same thing with [DateTime::getTimezone](http://php.net/manual/en/datetime.gettimezone.php) combined with [DateTime::getOffset](http://php.net/manual/en/datetime.getoffset.php).